### PR TITLE
Fix issues

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -32,6 +32,6 @@ dependencies {
 	testImplementation 'junit:junit:4.12'
 	androidTestImplementation 'androidx.test.ext:junit:1.1.1'
 	androidTestImplementation 'androidx.test.espresso:espresso-core:3.2.0'
-	implementation 'com.google.android.material:material:1.1.0-beta01'
+	implementation 'com.google.android.material:material:1.1.0-rc02'
 
 }

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -7,15 +7,15 @@
 	<androidx.constraintlayout.widget.ConstraintLayout
 		android:layout_width="match_parent"
 		android:layout_height="match_parent"
-		android:background="@color/colorPrimary" />
+		android:background="?attr/colorPrimary" />
 
-	<com.google.android.material.card.MaterialCardView
-		style="@style/BottomSheetCardView"
+	<FrameLayout
 		android:layout_width="match_parent"
 		android:layout_height="match_parent"
 		app:behavior_hideable="false"
 		app:behavior_peekHeight="96dp"
-		app:layout_behavior="com.google.android.material.bottomsheet.BottomSheetBehavior">
+		app:layout_behavior="@string/bottom_sheet_behavior"
+		style="?attr/bottomSheetStyle">
 
 		<androidx.constraintlayout.widget.ConstraintLayout
 			android:layout_width="match_parent"
@@ -43,7 +43,6 @@
 
 			<com.google.android.material.card.MaterialCardView
 				android:id="@+id/inner_mcv"
-				style="@style/BottomSheetCardView"
 				android:layout_width="0dp"
 				android:layout_height="wrap_content"
 				android:layout_margin="16dp"
@@ -76,7 +75,7 @@
 					android:id="@+id/four"
 					android:layout_width="match_parent"
 					android:layout_height="match_parent"
-					android:background="@color/colorPrimaryDark"
+					android:background="?attr/colorPrimaryDark"
 					android:padding="16dp"
 					android:text="This MaterialCardView is clipping the Textview that has a coloured background"
 					android:textColor="@android:color/white" />
@@ -85,7 +84,6 @@
 
 			<com.google.android.material.card.MaterialCardView
 				android:id="@+id/inner_mcv_3"
-				style="@style/BottomSheetCardView"
 				android:layout_width="0dp"
 				android:layout_height="wrap_content"
 				android:layout_margin="16dp"
@@ -98,7 +96,7 @@
 					android:id="@+id/five"
 					android:layout_width="match_parent"
 					android:layout_height="match_parent"
-					android:background="@color/colorPrimaryDark"
+					android:background="?attr/colorPrimaryDark"
 					android:padding="16dp"
 					android:text="This MaterialCardView is NOT clipping the Textview that has a coloured background. NOtice the rounded corners are gone even tho they should be visible. The difference here is that the rounded corners com from the shapeAppearanceOverlay. Is that expected?"
 					android:textColor="@android:color/white" />
@@ -107,7 +105,7 @@
 
 		</androidx.constraintlayout.widget.ConstraintLayout>
 
-	</com.google.android.material.card.MaterialCardView>
+	</FrameLayout>
 
 
 </androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -5,22 +5,28 @@
 		<item name="colorPrimary">@color/colorPrimary</item>
 		<item name="colorPrimaryDark">@color/colorPrimaryDark</item>
 		<item name="colorAccent">@color/colorAccent</item>
+		<item name="shapeAppearanceLargeComponent">@style/ShapeAppearance.LargeComponent</item>
+		<item name="bottomSheetStyle">@style/Widget.BottomSheet</item>
+		<item name="materialCardViewStyle">@style/Widget.CardView</item>
 	</style>
 
-	<style name="BottomSheetCardView" parent="@style/Widget.MaterialComponents.CardView">
-		<item name="cardPreventCornerOverlap">false</item>
-		<item name="cardBackgroundColor">@color/colorAccent</item>
-		<item name="shapeAppearanceOverlay">
-			@style/ShapeAppearanceOverlay.MaterialCardView.BottomSheet
-		</item>
-	</style>
-
-	<style name="ShapeAppearanceOverlay.MaterialCardView.BottomSheet" parent="">
+	<style name="ShapeAppearance.MediumComponent" parent="ShapeAppearance.MaterialComponents.MediumComponent">
 		<item name="cornerFamily">rounded</item>
-		<item name="cornerSizeTopRight">16dp</item>
-		<item name="cornerSizeTopLeft">16dp</item>
-		<item name="cornerSizeBottomRight">0dp</item>
-		<item name="cornerSizeBottomLeft">0dp</item>
+		<item name="cornerSize">16dp</item>
+	</style>
+
+	<style name="ShapeAppearance.LargeComponent" parent="ShapeAppearance.MaterialComponents.LargeComponent">
+		<item name="cornerFamily">rounded</item>
+		<item name="cornerSize">16dp</item>
+	</style>
+
+	<style name="Widget.BottomSheet" parent="@style/Widget.MaterialComponents.BottomSheet">
+		<item name="backgroundTint">?attr/colorAccent</item>
+	</style>
+
+	<style name="Widget.CardView" parent="@style/Widget.MaterialComponents.CardView">
+		<item name="cardPreventCornerOverlap">false</item>
+		<item name="cardBackgroundColor">?attr/colorAccent</item>
 	</style>
 
 </resources>


### PR DESCRIPTION
Hi @Sottti,

I have addressed most of the issues you were asking about in this PR:
- Changed to using a `FrameLayout` instead of a `MaterialCardView` for the root bottom sheet view. It is not necessary to use a card here as `BottomSheetBehavior` applies a `MaterialShapeDrawable` background to the root view
- Adjusted the styles - notice for bottom sheets you use `backgroundTint` for the bg color
- Set some default styles in the app theme and used color/style attrs where appropriate

To answer your other question - yes the animating of the bottom sheet corners to 0dp at the top is intentional. Not everyone is too happy about it though - see this [issue](https://github.com/material-components/material-components-android/issues/325) and this [pull request](https://github.com/material-components/material-components-android/pull/437).